### PR TITLE
Plotly JS Fix

### DIFF
--- a/dashboards/component/chart/chart.py
+++ b/dashboards/component/chart/chart.py
@@ -17,3 +17,6 @@ class Chart(Component):
 
     value: Optional[Union[Callable[..., Any], Type["ChartSerializer"]]] = None
     defer: Optional[Union[Callable[..., Any], Type["ChartSerializer"]]] = None
+
+    class Media:
+        js = ("dashboards/vendor/js/plotly.min.js",)

--- a/dashboards/component/map.py
+++ b/dashboards/component/map.py
@@ -15,3 +15,6 @@ class Map(Component):
     # we should also probably accept objects which have a to_json() on them
     value: Optional[str] = None
     defer: Optional[Callable[[HttpRequest], str]] = None
+
+    class Media:
+        js = ("dashboards/vendor/js/plotly.min.js",)


### PR DESCRIPTION
add Media to Chart and Map Components so that they load Ploty js library on render.